### PR TITLE
remove chez-isms to make portable R6RS code

### DIFF
--- a/dataframe.sls
+++ b/dataframe.sls
@@ -47,7 +47,7 @@
    rowtable->dataframe
    sort-expr)
 
-  (import (chezscheme)
+  (import (rnrs)
           (dataframe aggregate)
           (dataframe bind)
           (dataframe df)

--- a/dataframe/aggregate.sls
+++ b/dataframe/aggregate.sls
@@ -2,7 +2,7 @@
   (export dataframe-aggregate
           aggregate-expr)
 
-  (import (chezscheme)
+  (import (rnrs)
           (dataframe bind)
           (dataframe split)
           (only (dataframe df)

--- a/dataframe/bind.sls
+++ b/dataframe/bind.sls
@@ -3,7 +3,7 @@
           dataframe-bind
           dataframe-bind-all)
 
-  (import (chezscheme)
+  (import (rnrs)
           (only (dataframe df)
                 check-all-dataframes
                 dataframe-alist
@@ -13,6 +13,7 @@
                 dataframe-values
                 make-dataframe)   
           (only (dataframe helpers)
+                make-list
                 combine-names-ordered
                 get-all-names
                 get-all-unique-names

--- a/dataframe/df.sls
+++ b/dataframe/df.sls
@@ -29,7 +29,7 @@
    dataframe-write
    make-dataframe)
 
-  (import (chezscheme)
+  (import (rnrs)
           (dataframe helpers))
 
   ;; naming conventions ----------------------------------------------------------------------

--- a/dataframe/display.sls
+++ b/dataframe/display.sls
@@ -2,11 +2,12 @@
 (library (dataframe display)
   (export dataframe-display)
 
-  (import (chezscheme)
+  (import (rnrs)
           (only (dataframe df)
                 check-dataframe
                 dataframe-alist)    
           (only (dataframe helpers)
+                list-head
                 transpose))
 
   ;; lack of familiarity with `format` meant reinventing the wheel
@@ -76,7 +77,7 @@
   (define (string-adjust-length string column-width pad)
     (let* ([max-width (- column-width pad)]
            [string-new (if (> (string-length string) max-width)
-                           (string-truncate! string max-width)
+                           (substring 0 string max-width)
                            string)])
       (string-append
        (make-string (- column-width (string-length string-new)) #\ )

--- a/dataframe/filter.sls
+++ b/dataframe/filter.sls
@@ -5,7 +5,7 @@
           dataframe-partition
           filter-expr)
 
-  (import (chezscheme)
+  (import (rnrs)
           (only (dataframe df)
                 check-dataframe
                 check-df-names

--- a/dataframe/helpers.sls
+++ b/dataframe/helpers.sls
@@ -1,5 +1,11 @@
 (library (dataframe helpers)
   (export
+   list-head
+   make-list
+   add1
+   sub1
+   iota
+   enumerate
    add-names-ls-vals
    alist-modify
    alist-select
@@ -31,7 +37,7 @@
    transpose
    unique-rows)
 
-  (import (chezscheme))
+  (import (rnrs))
 
   ;; https://stackoverflow.com/questions/8382296/scheme-remove-duplicated-numbers-from-list
   (define (remove-duplicates ls)
@@ -219,7 +225,35 @@
       (assertion-violation who "columns not all same length")))
 
   
-  )
+(define (make-list n x)
+  (let loop ((n n) (r '()))
+    (if (= n 0)
+      r
+    (loop (- n 1) (cons x r)))))
+  
+(define (sub1 n) (- n 1))
+(define (add1 n) (+ n 1))
+
+;; simplified SRFI 1 iota (regular version will work)
+(define (iota count)
+  (define start 0)
+  (define step 1)
+  (let loop ((n 0) (r '()))
+    (if (= n count)
+	(reverse r)
+	(loop (+ 1 n)
+		(cons (+ start (* n step)) r)))))
+
+(define (enumerate lst)
+  (iota (length lst)))
+
+;; from SRFI-1 `take`
+(define (list-head lis k)
+  (let recur ((lis lis) (k k))
+    (if (zero? k) '()
+	(cons (car lis)
+	      (recur (cdr lis) (- k 1))))))
+)
 
 
 

--- a/dataframe/join.sls
+++ b/dataframe/join.sls
@@ -2,7 +2,7 @@
   (export dataframe-left-join
           dataframe-left-join-all)
 
-  (import (chezscheme)
+  (import (rnrs)
           (dataframe bind)
           (dataframe split)
           (only (dataframe df)
@@ -13,6 +13,7 @@
                 dataframe-alist
                 dataframe-dim)   
           (only (dataframe helpers)
+                make-list
                 not-in
                 check-names-unique
                 alist-drop

--- a/dataframe/modify.sls
+++ b/dataframe/modify.sls
@@ -4,7 +4,7 @@
           dataframe-modify-at
           modify-expr)
 
-  (import (chezscheme)
+  (import (rnrs)
           (only (dataframe df)
                 check-dataframe
                 check-df-names
@@ -12,6 +12,7 @@
                 dataframe-names
                 make-dataframe)   
           (only (dataframe helpers)
+                    make-list
                 alist-modify
                 alist-values-map
                 check-names))

--- a/dataframe/reshape.sls
+++ b/dataframe/reshape.sls
@@ -2,7 +2,7 @@
   (export dataframe-stack
           dataframe-spread)
 
-  (import (chezscheme)
+  (import (rnrs)
           (dataframe modify)
           (dataframe join)
           (dataframe split)

--- a/dataframe/rowtable.sls
+++ b/dataframe/rowtable.sls
@@ -5,13 +5,15 @@
    dataframe->rowtable
    rowtable->dataframe)
 
-  (import (chezscheme)
+  (import (rnrs)
           (only (dataframe df)
                 check-dataframe
                 dataframe-names
                 dataframe-values-map
                 make-dataframe)
           (only (dataframe helpers)
+                iota
+                    make-list
                 transpose))
 
   (define (dataframe->rowtable df)

--- a/dataframe/sort.sls
+++ b/dataframe/sort.sls
@@ -2,12 +2,13 @@
   (export dataframe-sort
           sort-expr)
 
-  (import (chezscheme)
+  (import (rnrs)
           (only (dataframe df)
                 check-dataframe
                 dataframe-alist
                 make-dataframe)   
           (only (dataframe helpers)
+                enumerate
                 add-names-ls-vals
                 alist-values-map
                 remove-duplicates))
@@ -42,7 +43,7 @@
   ;; sort list of values in increasing order by ranks
   (define (sort-vals ranks vals)
     (let ([ranks-vals (map cons ranks vals)])
-      (map cdr (sort (lambda (x y) (< (car x) (car y))) ranks-vals))))
+      (map cdr (list-sort (lambda (x y) (< (car x) (car y))) ranks-vals))))
   
   (define (sort-ls-vals ranks ls-vals)
     (map (lambda (vals) (sort-vals ranks vals)) ls-vals))
@@ -74,7 +75,7 @@
 
   ;; returns list of weighted rank values for every value in ls 
   (define (rank-list predicate ls weight)
-    (let* ([unique-sorted (sort predicate (remove-duplicates ls))]
+    (let* ([unique-sorted (list-sort predicate (remove-duplicates ls))]
            [ranks (map (lambda (x) (* x weight)) (enumerate unique-sorted))]
            [lookup (map cons unique-sorted ranks)]) 
       (map (lambda (x) (cdr (assoc x lookup))) ls)))

--- a/dataframe/split.sls
+++ b/dataframe/split.sls
@@ -2,7 +2,7 @@
   (export dataframe-split
           dataframe-split-helper)
 
-  (import (chezscheme)
+  (import (rnrs)
           (only (dataframe df)
                 check-df-names
                 dataframe-alist


### PR DESCRIPTION
1. Changed `(chezscheme)` import to `(rnrs)` everywhere.
2. Added a few routines to `helpers.sls` to make up the difference.  Some come from SRFI 1.
3. Change the remaining Chez-specific procedures to use equivalent R6RS procedures.